### PR TITLE
Fix/loader save data creation

### DIFF
--- a/Assets/AssetGraph/Editor.meta
+++ b/Assets/AssetGraph/Editor.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: c090d93d25093494ba896c085743a1b8
+guid: 02247b53965caea429617de2f7262a38
 folderAsset: yes
-timeCreated: 1481649688
+timeCreated: 1481714842
 licenseType: Pro
 DefaultImporter:
   userData: 

--- a/Assets/AssetGraph/Editor/FolderInspector.cs
+++ b/Assets/AssetGraph/Editor/FolderInspector.cs
@@ -14,24 +14,28 @@ public class FolderInspector : Editor {
 
 	private bool IsValid {
 		get {
-			bool shouldPaintInspector = false;
-			var currentPath = AssetDatabase.GetAssetPath(target);
-			if(Directory.Exists(currentPath)) {
-				if(currentPath != path) {
-					path = currentPath;
-					CheckForLoader();
-				}
 
-				shouldPaintInspector = !(path + "/").Contains(AssetBundleGraphSettings.ASSETBUNDLEGRAPH_PATH);
-			}
-			return shouldPaintInspector;
-		}
+            bool shouldPaintInspector = false;
+            var currentPath = AssetDatabase.GetAssetPath(target);
+            if(Directory.Exists(currentPath)) {
+                if(currentPath != path) {
+                    path = currentPath;
+                    CheckForLoader();
+                }
+                
+                shouldPaintInspector = !(path + "/").Contains(AssetBundleGraphSettings.ASSETBUNDLEGRAPH_PATH);
+            }
+            return shouldPaintInspector;
+        }
 	}
 
-	private void CheckForLoader() {
-		LoaderSaveData loaderSaveData = LoaderSaveData.LoadFromDisk();
-		loader = loaderSaveData.GetBestLoaderData(path);
-	}
+    private void CheckForLoader() {
+        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+            return;
+        }
+        LoaderSaveData loaderSaveData = LoaderSaveData.LoadFromDisk();
+        loader = loaderSaveData.GetBestLoaderData(path);
+    }
 
 	public override void OnInspectorGUI() {
 		base.OnInspectorGUI();

--- a/Assets/AssetGraph/Editor/FolderInspector.cs
+++ b/Assets/AssetGraph/Editor/FolderInspector.cs
@@ -15,27 +15,27 @@ public class FolderInspector : Editor {
 	private bool IsValid {
 		get {
 
-            bool shouldPaintInspector = false;
-            var currentPath = AssetDatabase.GetAssetPath(target);
-            if(Directory.Exists(currentPath)) {
-                if(currentPath != path) {
-                    path = currentPath;
-                    CheckForLoader();
-                }
-                
-                shouldPaintInspector = !(path + "/").Contains(AssetBundleGraphSettings.ASSETBUNDLEGRAPH_PATH);
-            }
-            return shouldPaintInspector;
-        }
+			bool shouldPaintInspector = false;
+			var currentPath = AssetDatabase.GetAssetPath(target);
+			if(Directory.Exists(currentPath)) {
+				if(currentPath != path) {
+					path = currentPath;
+					CheckForLoader();
+				}
+				
+				shouldPaintInspector = !(path + "/").Contains(AssetBundleGraphSettings.ASSETBUNDLEGRAPH_PATH);
+			}
+			return shouldPaintInspector;
+		}
 	}
 
-    private void CheckForLoader() {
-        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
-            return;
-        }
-        LoaderSaveData loaderSaveData = LoaderSaveData.LoadFromDisk();
-        loader = loaderSaveData.GetBestLoaderData(path);
-    }
+	private void CheckForLoader() {
+		if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+			return;
+		}
+		LoaderSaveData loaderSaveData = LoaderSaveData.LoadFromDisk();
+		loader = loaderSaveData.GetBestLoaderData(path);
+	}
 
 	public override void OnInspectorGUI() {
 		base.OnInspectorGUI();

--- a/Assets/AssetGraph/Editor/PreProcessor.cs
+++ b/Assets/AssetGraph/Editor/PreProcessor.cs
@@ -41,21 +41,21 @@ public class PreProcessor : AssetPostprocessor {
 	}
 
 	void OnPreprocessTexture() {
-        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
-            return;
-        }
+		if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+			return;
+		}
 
-        if(!wasMoving) {
+		if(!wasMoving) {
 			GenericProcess(assetPath);
 		}
 	}
 
 	void OnPreprocessModel() {
-        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
-            return;
-        }
+		if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+			return;
+		}
 
-        if(!wasMoving) {
+		if(!wasMoving) {
 			GenericProcess(assetPath);
 		}
 
@@ -65,22 +65,22 @@ public class PreProcessor : AssetPostprocessor {
 	}
 
 	void OnPreprocessAudio() {
-        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
-            return;
-        }
+		if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+			return;
+		}
 
-        if(!wasMoving) {
+		if(!wasMoving) {
 			GenericProcess(assetPath);
 		}
 	}
 
 	// TODO: PostProcess assets in a single run 
 	static void OnPostprocessAllAssets(string[] imported, string[] deleted, string[] moved, string[] movedFromAssetPaths) {
-        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
-            return;
-        }
+		if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+			return;
+		}
 
-        float i = 0;
+		float i = 0;
 		bool clearBar = false;
 
 		foreach(string path in AssetsToPostProcess) {
@@ -107,7 +107,7 @@ public class PreProcessor : AssetPostprocessor {
 
 		AssetsToPostProcess.Clear();
 	}
-    
+	
 
 	static void GenericProcess(string path, bool isPostProcessing = false, bool isMoving = false) {
 		var loader = LoaderData.GetBestLoaderData(path);

--- a/Assets/AssetGraph/Editor/PreProcessor.cs
+++ b/Assets/AssetGraph/Editor/PreProcessor.cs
@@ -41,13 +41,21 @@ public class PreProcessor : AssetPostprocessor {
 	}
 
 	void OnPreprocessTexture() {
-		if(!wasMoving) {
+        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+            return;
+        }
+
+        if(!wasMoving) {
 			GenericProcess(assetPath);
 		}
 	}
 
 	void OnPreprocessModel() {
-		if(!wasMoving) {
+        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+            return;
+        }
+
+        if(!wasMoving) {
 			GenericProcess(assetPath);
 		}
 
@@ -57,14 +65,22 @@ public class PreProcessor : AssetPostprocessor {
 	}
 
 	void OnPreprocessAudio() {
-		if(!wasMoving) {
+        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+            return;
+        }
+
+        if(!wasMoving) {
 			GenericProcess(assetPath);
 		}
 	}
 
 	// TODO: PostProcess assets in a single run 
 	static void OnPostprocessAllAssets(string[] imported, string[] deleted, string[] moved, string[] movedFromAssetPaths) {
-		float i = 0;
+        if(!LoaderSaveData.IsLoaderDataAvailableAtDisk()) {
+            return;
+        }
+
+        float i = 0;
 		bool clearBar = false;
 
 		foreach(string path in AssetsToPostProcess) {
@@ -91,10 +107,9 @@ public class PreProcessor : AssetPostprocessor {
 
 		AssetsToPostProcess.Clear();
 	}
+    
 
-
-
-	static void GenericProcess(string path, bool isPostProcessing = false, bool isMoving = false) {		
+	static void GenericProcess(string path, bool isPostProcessing = false, bool isMoving = false) {
 		var loader = LoaderData.GetBestLoaderData(path);
 
 		bool execute = false;

--- a/Assets/AssetGraph/Editor/System/Model/SaveData.cs
+++ b/Assets/AssetGraph/Editor/System/Model/SaveData.cs
@@ -179,7 +179,7 @@ namespace AssetBundleGraph {
 		public static SaveData RecreateDataOnDisk () {
 			SaveData newSaveData = new SaveData();
 			newSaveData.Save();
-            AssetDatabase.Refresh();
+			AssetDatabase.Refresh();
 			return newSaveData;
 		}
 			
@@ -324,12 +324,12 @@ namespace AssetBundleGraph {
 		}
 
 		public void Save() {
-            var dir = SaveData.SaveDataDirectoryPath;
-            if(!Directory.Exists(dir)) {
-                Directory.CreateDirectory(dir);
-            }
+			var dir = SaveData.SaveDataDirectoryPath;
+			if(!Directory.Exists(dir)) {
+				Directory.CreateDirectory(dir);
+			}
 
-            var serializedData = Json.Serialize(ToJsonDictionary());
+			var serializedData = Json.Serialize(ToJsonDictionary());
 			var loaderPrettyfied = Json.Prettify(serializedData);
 
 			using(var sw = new StreamWriter(LoaderSaveDataPath)) {
@@ -377,7 +377,7 @@ namespace AssetBundleGraph {
 		public static LoaderSaveData RecreateDataOnDisk() {
 			LoaderSaveData lSaveData = new LoaderSaveData();
 			lSaveData.Save();
-            AssetDatabase.Refresh();
+			AssetDatabase.Refresh();
 			return lSaveData;
 		}
 

--- a/Assets/AssetGraph/Editor/System/Model/SaveData.cs
+++ b/Assets/AssetGraph/Editor/System/Model/SaveData.cs
@@ -179,6 +179,7 @@ namespace AssetBundleGraph {
 		public static SaveData RecreateDataOnDisk () {
 			SaveData newSaveData = new SaveData();
 			newSaveData.Save();
+            AssetDatabase.Refresh();
 			return newSaveData;
 		}
 			
@@ -293,7 +294,7 @@ namespace AssetBundleGraph {
 			}
 		}
 
-		private static string SaveLoaderDataPath {
+		private static string LoaderSaveDataPath {
 			get {
 				return FileUtility.PathCombine(SaveData.SaveDataDirectoryPath, AssetBundleGraphSettings.ASSETBUNDLEGRAPH_LOADER_DATA_NAME);
 			}
@@ -323,10 +324,15 @@ namespace AssetBundleGraph {
 		}
 
 		public void Save() {
-			var serializedData = Json.Serialize(ToJsonDictionary());
+            var dir = SaveData.SaveDataDirectoryPath;
+            if(!Directory.Exists(dir)) {
+                Directory.CreateDirectory(dir);
+            }
+
+            var serializedData = Json.Serialize(ToJsonDictionary());
 			var loaderPrettyfied = Json.Prettify(serializedData);
 
-			using(var sw = new StreamWriter(SaveLoaderDataPath)) {
+			using(var sw = new StreamWriter(LoaderSaveDataPath)) {
 				sw.Write(loaderPrettyfied);
 			}
 		}
@@ -371,6 +377,7 @@ namespace AssetBundleGraph {
 		public static LoaderSaveData RecreateDataOnDisk() {
 			LoaderSaveData lSaveData = new LoaderSaveData();
 			lSaveData.Save();
+            AssetDatabase.Refresh();
 			return lSaveData;
 		}
 
@@ -381,21 +388,21 @@ namespace AssetBundleGraph {
 
 			try {
 				var dataStr = string.Empty;
-				using(var sr = new StreamReader(SaveLoaderDataPath)) {
+				using(var sr = new StreamReader(LoaderSaveDataPath)) {
 					dataStr = sr.ReadToEnd();
 				}
 				var deserialized = Json.Deserialize(dataStr) as Dictionary<string, object>;
 
 				return new LoaderSaveData(deserialized);
 			} catch(Exception e) {
-				Debug.LogError("Failed to deserialize AssetBundleGraph settings. Error:" + e + " File:" + SaveLoaderDataPath);
+				Debug.LogError("Failed to deserialize AssetBundleGraph settings. Error:" + e + " File:" + LoaderSaveDataPath);
 			}
 
 			return new LoaderSaveData();
 		}
 
 		public static bool IsLoaderDataAvailableAtDisk() {
-			return File.Exists(SaveLoaderDataPath);
+			return File.Exists(LoaderSaveDataPath);
 		}
 	}
 }

--- a/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
+++ b/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
@@ -55,11 +55,11 @@ namespace AssetBundleGraph {
 				var output = new Dictionary<string, List<Asset>>();
 
 				foreach(var groupKey in inputGroupAssets.Keys) {
-                    var filteringKeyword = string.IsNullOrEmpty(filter.FilterKeyword) ? "*" : filter.FilterKeyword;
-                    var assets = inputGroupAssets[groupKey];
+					var filteringKeyword = string.IsNullOrEmpty(filter.FilterKeyword) ? "*" : filter.FilterKeyword;
+					var assets = inputGroupAssets[groupKey];
 					var filteringAssets = new List<FilterableAsset>();
 					assets.ForEach(a => filteringAssets.Add(new FilterableAsset(a)));
-                    
+					
 
 					// filter by keyword first
 					List<FilterableAsset> keywordContainsAssets = filteringAssets.Where(
@@ -92,43 +92,43 @@ namespace AssetBundleGraph {
 				Output(connToChild, output, null);
 			}
 		}
-        
-        public const char WildcardMultiChar = '*';
-        public const string WildcardDeep = "**";
-        public const char WildcardOneChar = '?';
+		
+		public const char WildcardMultiChar = '*';
+		public const string WildcardDeep = "**";
+		public const char WildcardOneChar = '?';
 
-        public static bool GlobMatch(string pattern, string value) {    
-            bool deep = pattern.Contains(WildcardDeep);
-            if(deep) {
-                pattern = pattern.Replace(WildcardDeep, WildcardMultiChar.ToString());
-            } else if(value.Split(Path.DirectorySeparatorChar).Length != pattern.Split(Path.DirectorySeparatorChar).Length) {
-                return false;
-            }
+		public static bool GlobMatch(string pattern, string value) {    
+			bool deep = pattern.Contains(WildcardDeep);
+			if(deep) {
+				pattern = pattern.Replace(WildcardDeep, WildcardMultiChar.ToString());
+			} else if(value.Split(Path.DirectorySeparatorChar).Length != pattern.Split(Path.DirectorySeparatorChar).Length) {
+				return false;
+			}
 
-            int pos = 0;
-            while(pattern.Length != pos) {
-                switch(pattern[pos]) {
-                    case WildcardOneChar:
-                        break;
+			int pos = 0;
+			while(pattern.Length != pos) {
+				switch(pattern[pos]) {
+					case WildcardOneChar:
+						break;
 
-                    case WildcardMultiChar:
-                        for(int i = value.Length; i >= pos; i--) {
-                            if(GlobMatch(pattern.Substring(pos + 1), value.Substring(i))) {
-                                return true;
-                            }
-                        }
-                        return false;
+					case WildcardMultiChar:
+						for(int i = value.Length; i >= pos; i--) {
+							if(GlobMatch(pattern.Substring(pos + 1), value.Substring(i))) {
+								return true;
+							}
+						}
+						return false;
 
-                    default:
-                        if(value.Length == pos || char.ToUpper(pattern[pos]) != char.ToUpper(value[pos])) {
-                            return false;
-                        }
-                        break;
-                }
+					default:
+						if(value.Length == pos || char.ToUpper(pattern[pos]) != char.ToUpper(value[pos])) {
+							return false;
+						}
+						break;
+				}
 
-                pos++;
-            }
-            return value.Length == pos;
-        }
-    }
+				pos++;
+			}
+			return value.Length == pos;
+		}
+	}
 }

--- a/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
+++ b/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
@@ -97,7 +97,7 @@ namespace AssetBundleGraph {
 		public const string WildcardDeep = "**";
 		public const char WildcardOneChar = '?';
 
-		public static bool GlobMatch(string pattern, string value) {    
+		private static bool GlobMatch(string pattern, string value) {    
 			bool deep = pattern.Contains(WildcardDeep);
 			if(deep) {
 				pattern = pattern.Replace(WildcardDeep, WildcardMultiChar.ToString());

--- a/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
+++ b/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
@@ -4,7 +4,7 @@ using UnityEditor;
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using System.IO;
 
 namespace AssetBundleGraph {
 	public class IntegratedGUIFilter : INodeOperation {
@@ -55,16 +55,17 @@ namespace AssetBundleGraph {
 				var output = new Dictionary<string, List<Asset>>();
 
 				foreach(var groupKey in inputGroupAssets.Keys) {
-					var assets = inputGroupAssets[groupKey];
+                    var filteringKeyword = string.IsNullOrEmpty(filter.FilterKeyword) ? "*" : filter.FilterKeyword;
+                    var assets = inputGroupAssets[groupKey];
 					var filteringAssets = new List<FilterableAsset>();
 					assets.ForEach(a => filteringAssets.Add(new FilterableAsset(a)));
-
+                    
 
 					// filter by keyword first
 					List<FilterableAsset> keywordContainsAssets = filteringAssets.Where(
 						assetData => 
 						!assetData.isFiltered && 
-						(filter.IsExclusion ^ Regex.IsMatch(assetData.asset.importFrom, WildcardToRegex(filter.FilterKeyword), RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace))
+						(filter.IsExclusion ^ GlobMatch(filteringKeyword, assetData.asset.importFrom))
 					).ToList();
 
 					List<FilterableAsset> finalFilteredAsset = new List<FilterableAsset>();
@@ -91,18 +92,43 @@ namespace AssetBundleGraph {
 				Output(connToChild, output, null);
 			}
 		}
+        
+        public const char WildcardMultiChar = '*';
+        public const string WildcardDeep = "**";
+        public const char WildcardOneChar = '?';
 
+        public static bool GlobMatch(string pattern, string value) {    
+            bool deep = pattern.Contains(WildcardDeep);
+            if(deep) {
+                pattern = pattern.Replace(WildcardDeep, WildcardMultiChar.ToString());
+            } else if(value.Split(Path.DirectorySeparatorChar).Length != pattern.Split(Path.DirectorySeparatorChar).Length) {
+                return false;
+            }
 
-		public static string WildcardToRegex(string pattern) {
-			// empty filter keyword means 'no filtering'.
-			if (string.IsNullOrEmpty (pattern)) {
-				pattern = "*";
-			}
-				
-			return "^" + Regex.Escape(pattern)
-							  .Replace(@"\*", ".*")
-							  .Replace(@"\?", ".")
-					   + "$";
-		}
-	}
+            int pos = 0;
+            while(pattern.Length != pos) {
+                switch(pattern[pos]) {
+                    case WildcardOneChar:
+                        break;
+
+                    case WildcardMultiChar:
+                        for(int i = value.Length; i >= pos; i--) {
+                            if(GlobMatch(pattern.Substring(pos + 1), value.Substring(i))) {
+                                return true;
+                            }
+                        }
+                        return false;
+
+                    default:
+                        if(value.Length == pos || char.ToUpper(pattern[pos]) != char.ToUpper(value[pos])) {
+                            return false;
+                        }
+                        break;
+                }
+
+                pos++;
+            }
+            return value.Length == pos;
+        }
+    }
 }


### PR DESCRIPTION
Fix: When having an empty project without savedata, selecting a folder would cause a crash because the LoaderSaveGame was being created without folder.
Fix/Refactor: Changed WildcardToRegex to a wildcard search.