### PR TITLE
Fix: Empty filter keyword means 'no filtering'

### DIFF
--- a/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
+++ b/Assets/AssetGraph/Editor/System/NodeOperation/Integrated/IntegratedGUIFilter.cs
@@ -55,7 +55,7 @@ namespace AssetBundleGraph {
 				var output = new Dictionary<string, List<Asset>>();
 
 				foreach(var groupKey in inputGroupAssets.Keys) {
-					var filteringKeyword = string.IsNullOrEmpty(filter.FilterKeyword) ? "*" : filter.FilterKeyword;
+					var filteringKeyword = string.IsNullOrEmpty(filter.FilterKeyword) ? WildcardDeep : filter.FilterKeyword;
 					var assets = inputGroupAssets[groupKey];
 					var filteringAssets = new List<FilterableAsset>();
 					assets.ForEach(a => filteringAssets.Add(new FilterableAsset(a)));


### PR DESCRIPTION
Before:
- `(Empty)` ... matched nothing.
- `*` ... matched nothing.
- `**` ... matched everything.

After:
- `(Empty)` ... matched everything.
- `*` ... matched nothing. Is this correct?
- `**` ... matched everything.